### PR TITLE
Configure ruff and Claude Code permissions for Python dev

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python3:*)",
+      "Bash(git pull:*)"
+    ]
+  }
+}

--- a/nvim/lua/plugins/astrolsp.lua
+++ b/nvim/lua/plugins/astrolsp.lua
@@ -46,6 +46,13 @@ return {
     ---@diagnostic disable: missing-fields
     config = {
       -- clangd = { capabilities = { offsetEncoding = "utf-8" } },
+      ruff = {
+        init_options = {
+          settings = {
+            lint = { ignore = { "E501" } },
+          },
+        },
+      },
     },
     -- customize how language servers are attached
     handlers = {
@@ -55,6 +62,7 @@ return {
       -- the key is the server that is being setup with `lspconfig`
       -- rust_analyzer = false, -- setting a handler to false will disable the set up of that language server
       -- pyright = function(_, opts) require("lspconfig").pyright.setup(opts) end -- or a custom handler function can be passed
+      pylsp = false,
     },
     -- Configure buffer local auto commands to add when attaching a language server
     autocmds = {


### PR DESCRIPTION
[Review changes](https://github.com/mos3abof/dotfiles/pull/8/changes/8c995cb583be89e1292d91c731ce2d02a4989a21)

<!-- jellycat -->

## Summary

- Add `.claude/settings.local.json` allowlisting `python3` and `git
  pull` Bash commands so they run without permission prompts.

- Configure the ruff LSP to ignore the E501 (line-too-long) lint rule.

- Disable the pylsp language server so it doesn't conflict with ruff.

## Test Plan

- Open a Python file in nvim and confirm no `E501` diagnostics appear
  and only ruff is attached (`:LspInfo`).
- Confirm `python3` and `git pull` no longer trigger Claude Code
  prompts.