### PR TITLE
Persist and restore Claude Code sessions across tmux restarts

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -128,8 +128,30 @@ set -g @tokyo-night-tmux_date_format DMY
 set -g @tokyo-night-tmux_time_format 12H
 set -g @tokyo-night-tmux_show_hostname 1
 
-# set -g @resurrect-capture-pane-contents 'on'
-# set -g @continuum-restore 'on'
+# --- tmux-resurrect + tmux-continuum: persist/restore Claude Code sessions ---
+# Declared AFTER the theme plugin so continuum's status-right save hook is not
+# clobbered by tokyo-night-tmux. Guide:
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+
+set -g @continuum-save-interval '10'
+set -g @continuum-restore 'on'
+set -g @resurrect-capture-pane-contents 'on'
+# Whitelist the process(es) Claude Code runs as so resurrect saves/restores them.
+# The `~` prefix matches the process anywhere in the command line. Verify with the
+# test step that your Claude panes show `--resume <uuid>` in the save file.
+set -g @resurrect-processes '"~claude"'
+set -g @resurrect-hook-post-save-layout "$HOME/.tmux/scripts/fix-claude-sessions.sh"
+
+# Opportunistic saves on pane/window activity. Harmless in normal tmux, and a
+# safety net in case the theme owns status-right (which would suppress
+# continuum's built-in interval save).
+set-hook -g pane-focus-in "run-shell -b '$HOME/.tmux/plugins/tmux-continuum/scripts/continuum_save.sh'"
+set-hook -g window-pane-changed "run-shell -b '$HOME/.tmux/plugins/tmux-continuum/scripts/continuum_save.sh'"
+# NOTE: the guide's step (c) background timer (continuum-periodic-save.sh +
+# `run-shell` line) is intentionally OMITTED — it only exists to work around
+# iTerm2 `-CC` control mode, and it depends on `flock`, which is not installed on
+# macOS. In normal tmux, the interval save + hooks above cover periodic saving.
 
 # Initialize TMUX plugin manager.
 # Keep this line at the very bottom of tmux.conf.


### PR DESCRIPTION
[Review changes](https://github.com/mos3abof/dotfiles/pull/9/changes/96b3facd6c700800d4d5006c24139e6089f6280c)

<!-- jellycat -->

## Summary

I keep losing my Claude Code panes whenever the tmux server restarts or
the machine reboots — every `--resume` thread gone, and no quick way
back. This wires up tmux-resurrect + tmux-continuum (until now sitting
commented-out) so those panes come back on their own.

Better to have the sessions saved and not need them, than to reach for a
resume and find nothing there.

## Details

The two plugins are declared *after* the tokyo-night theme — order
matters here, because the theme owns `status-right` and will happily
clobber continuum's save hook if it loads last.

- `@continuum-restore on`, saving every 10 minutes, with
  `@resurrect-capture-pane-contents on` so scrollback comes back too.

- `@resurrect-processes` whitelists the `claude` process so its panes are saved
  and restored with their `--resume <uuid>` intact.

- `fix-claude-sessions.sh` runs as a post-save-layout hook to tidy the entries.

- Extra saves on `pane-focus-in` / `window-pane-changed`. Harmless in normal
  tmux, and a safety net if the theme ends up owning `status-right` and quietly
  suppresses continuum's interval save — better belt-and-braces than a silent
  gap.


## Test Plan

Reload, install, and confirm a Claude pane is actually captured:

```
❯ tmux source-file ~/.tmux/tmux.conf
❯ grep -o -- '--resume [a-f0-9-]*' ~/.tmux/resurrect/last
```

Then prove it survives a full restart:

```
❯ tmux kill-server
❯ tmux   # continuum restores automatically; the Claude panes reappear, mid-thread
```